### PR TITLE
Import all kind of Nodes

### DIFF
--- a/Classes/Controller/ImportController.php
+++ b/Classes/Controller/ImportController.php
@@ -40,7 +40,7 @@ class ImportController extends ActionController
      */
     public function indexAction()
     {
-        $nodeTypes = $this->nodeTypeManager->getSubNodeTypes('Neos.Neos:Document', false);
+        $nodeTypes = $this->nodeTypeManager->getNodeTypes(false);
 
         $nodeTypeOptions = [];
         foreach ($nodeTypes as $nodeType) {


### PR DESCRIPTION
I had to import Nodes that are not Sub of 'Neos.Neos:Document'. If there is no reason to restrict this it could be a general importer.